### PR TITLE
fabric: fix Puzzles Lib mob drops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,4 @@
-## Fabric, NeoForge & Paper
+## Fabric
 
-- add the `ignoreBlocks` config option ([**#95**](https://github.com/btwonion/magnetic/pull/95))
-    - ignore item and experience drops from selected source blocks
-    - accepts block IDs and tags
-
-## Fabric & NeoForge
-
-- add support for NeoForge ([**#94**](https://github.com/btwonion/magnetic/pull/94))
-- add support for Minecraft 1.21.1, 1.21.11, 26.1.1–26.1.2, and 26.2
-- support FallingTree, KleeSlabs, RightClickHarvest, TreeHarvester, and Veinminer on both mod loaders
+- fix mob drops not being collected when Puzzles Lib defers spawning them ([**#97**](https://github.com/btwonion/magnetic/issues/97))
+    - restores compatibility with Pick Up Notifier on Fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ modId=magnetic
 description=Magnetic enchantment: Drops and XP fly straight into your inventory
 
 beta=
-featureVersion=3.14.0
+featureVersion=3.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ modId=magnetic
 description=Magnetic enchantment: Drops and XP fly straight into your inventory
 
 beta=
-featureVersion=3.13.0
+featureVersion=3.14.0

--- a/mod/src/main/java/dev/nyon/magnetic/mixins/compat/CompatMixinPlugin.java
+++ b/mod/src/main/java/dev/nyon/magnetic/mixins/compat/CompatMixinPlugin.java
@@ -28,6 +28,7 @@ public class CompatMixinPlugin implements IMixinConfigPlugin {
             case "fallingtree" -> "fallingtree";
             case "kleeslabs" -> "kleeslabs";
             case "treeharvester" -> "treeharvester";
+            case "puzzleslib" -> /*? if fabric {*/ "puzzleslib" /*?} else {*/ /*null *//*?}*/;
             default -> null;
         };
     }

--- a/mod/src/main/java/dev/nyon/magnetic/mixins/compat/puzzleslib/FabricEventImplHelperMixin.java
+++ b/mod/src/main/java/dev/nyon/magnetic/mixins/compat/puzzleslib/FabricEventImplHelperMixin.java
@@ -1,0 +1,41 @@
+package dev.nyon.magnetic.mixins.compat.puzzleslib;
+
+import dev.nyon.magnetic.extensions.MagneticCheckKt;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static dev.nyon.magnetic.utils.MixinHelper.threadLocal;
+
+@Pseudo
+@Mixin(targets = "fuzs.puzzleslib.fabric.impl.event.FabricEventImplHelper", remap = false)
+public class FabricEventImplHelperMixin {
+
+    @Inject(method = "tryOnLivingDrops", at = @At("HEAD"), remap = false)
+    private static void setPlayerOnCapturedDrops(
+        LivingEntity entity,
+        DamageSource source,
+        int lastHurtByPlayerMemoryTime,
+        CallbackInfoReturnable<Boolean> cir
+    ) {
+        if (!(source.getEntity() instanceof ServerPlayer player)) return;
+        if (MagneticCheckKt.isIgnored(entity.getType())) return;
+        if (MagneticCheckKt.failsLongRangeCheck(entity, player)) return;
+        threadLocal.set(player);
+    }
+
+    @Inject(method = "tryOnLivingDrops", at = @At("RETURN"), remap = false)
+    private static void clearPlayerOnCapturedDrops(
+        LivingEntity entity,
+        DamageSource source,
+        int lastHurtByPlayerMemoryTime,
+        CallbackInfoReturnable<Boolean> cir
+    ) {
+        threadLocal.remove();
+    }
+}

--- a/mod/src/main/resources/magnetic.compat.mixins.json
+++ b/mod/src/main/resources/magnetic.compat.mixins.json
@@ -11,6 +11,7 @@
         "fallingtree.TreeBreakingHandlerMixin",
         "kleeslabs.BlockBreakHandlerMixin",
         "kleeslabs.BreakBlockEventAccessor",
+        "puzzleslib.FabricEventImplHelperMixin",
         "rightclickharvest.RightClickHarvestMixin",
         "treeharvester.LeafEventsMixin",
         "treeharvester.LeafProcessingMixin",


### PR DESCRIPTION
## Summary

- preserve the killing-player context while Puzzles Lib emits captured mob drops
- activate the compatibility mixin only on Fabric when Puzzles Lib is loaded
- bump the feature version to 3.14.0 and update the changelog

## Root cause

Puzzles Lib captures mob drops during `LivingEntity.dropAllDeathLoot` and spawns them later from its living-drops callback. Magnetic cleared its thread-local killing-player context before that callback ran, so the deferred item entities were no longer associated with the player and were not collected.

## Impact

Mob drops are collected normally again when Puzzles Lib is present, including installations using Pick Up Notifier.

## Validation

- `./gradlew :mod:26.2-fabric:build`
- `./gradlew build`

Closes #97