### PR TITLE
Fix animation entity retention

### DIFF
--- a/mod/src/gametestCommon/java/dev/nyon/magnetic/gametest/MagneticGameTestScenario.java
+++ b/mod/src/gametestCommon/java/dev/nyon/magnetic/gametest/MagneticGameTestScenario.java
@@ -1,5 +1,6 @@
 package dev.nyon.magnetic.gametest;
 
+import dev.nyon.magnetic.Animation;
 import dev.nyon.magnetic.config.Config;
 import dev.nyon.magnetic.config.ConfigKt;
 import dev.nyon.magnetic.config.conditions.ConditionChain;
@@ -9,6 +10,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityTypes;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -34,6 +36,7 @@ public final class MagneticGameTestScenario {
             verifyItemTogglePreservesDrop(helper, player);
             verifyExperienceIsCollected(helper, player);
             verifyFullInventoryPreservesDrop(helper, player);
+            verifyRemovedAnimatedItemsAreUntracked(helper, player);
             helper.succeed();
         } finally {
             ConfigKt.setConfig(previousConfig);
@@ -47,6 +50,28 @@ public final class MagneticGameTestScenario {
         assertEquals(helper, 0, count(player, Items.DIRT), "inactive Magnetic changed the inventory");
         helper.assertItemEntityPresent(Items.DIRT, DROP_POS, 2.0);
         helper.despawnItem(DROP_POS, 2.0);
+    }
+
+    private static void verifyRemovedAnimatedItemsAreUntracked(GameTestHelper helper, ServerPlayer player) {
+        Config config = testConfig("", true, true);
+        config.getAnimation().setEnabled(true);
+        ConfigKt.setConfig(config);
+
+        ItemEntity itemEntity = Animation.INSTANCE.pullItemToPlayer(
+            new ItemStack(Items.DIRT),
+            Vec3.atCenterOf(helper.absolutePos(DROP_POS)),
+            player
+        );
+        if (!Animation.INSTANCE.tracksItem(itemEntity)) {
+            fail(helper, "animation did not track its spawned item");
+        }
+
+        itemEntity.discard();
+        Animation.INSTANCE.tick();
+
+        if (Animation.INSTANCE.tracksItem(itemEntity)) {
+            fail(helper, "animation retained a removed item");
+        }
     }
 
     private static void verifyItemsAreCollected(GameTestHelper helper, ServerPlayer player) {

--- a/mod/src/main/kotlin/dev/nyon/magnetic/Animation.kt
+++ b/mod/src/main/kotlin/dev/nyon/magnetic/Animation.kt
@@ -2,67 +2,64 @@ package dev.nyon.magnetic
 
 import dev.nyon.magnetic.config.config
 import dev.nyon.magnetic.utils.MixinHelper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.phys.Vec3
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 object Animation {
-    private val animationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val blocksPerTick = config.animation.blocksPerSecond / 20
-    private val trackedItemEntities = mutableMapOf<ItemEntity, ServerPlayer>()
-    private val trackedItemEntitiesMutex = Mutex()
+    private val trackedItemEntities = ConcurrentHashMap<ItemEntity, UUID>()
 
-    fun pullItemToPlayer(item: ItemStack, pos: Vec3, player: ServerPlayer) {
+    fun pullItemToPlayer(item: ItemStack, pos: Vec3, player: ServerPlayer): ItemEntity {
         val itemEntity = ItemEntity(player.level(), pos.x, pos.y, pos.z, item)
         if (!config.animation.canOtherPlayersPickup) itemEntity.setTarget(player.uuid)
         MixinHelper.animationSkip.set(true)
-        try {
+        val spawned = try {
             player.level().addFreshEntity(itemEntity)
         } finally {
             MixinHelper.animationSkip.remove()
         }
-        animationScope.launch {
-            trackedItemEntitiesMutex.withLock {
-                trackedItemEntities[itemEntity] = player
-            }
-        }
+        if (spawned) trackedItemEntities[itemEntity] = player.uuid
+        return itemEntity
     }
 
-    internal fun tick() {
-        animationScope.launch {
-            val copiedItemEntities: Map<ItemEntity, ServerPlayer>
-            trackedItemEntitiesMutex.withLock {
-                copiedItemEntities = trackedItemEntities.toMap()
+    fun tick() {
+        trackedItemEntities.forEach { (itemEntity, targetId) ->
+            if (!itemEntity.isAlive) {
+                untrackEntity(itemEntity, targetId)
+                return@forEach
             }
 
-            copiedItemEntities.forEach { (itemEntity, target) ->
-                val targetPos = target.position()
-                val itemEntityPos = itemEntity.position()
-                val vec = targetPos.subtract(itemEntityPos)
-                val length = vec.length()
-                val tickPart = blocksPerTick / length
-                val tickVec = vec.multiply(
-                    tickPart,
-                    if (itemEntity.horizontalCollision) tickPart * 2 else tickPart,
-                    tickPart
-                )
-                itemEntity.addDeltaMovement(tickVec)
+            val target = itemEntity.level().server?.playerList?.getPlayer(targetId)
+            if (target == null || !target.isAlive || target.level() !== itemEntity.level()) {
+                untrackEntity(itemEntity, targetId)
+                return@forEach
             }
+
+            val vec = target.position().subtract(itemEntity.position())
+            val length = vec.length()
+            if (length == 0.0) return@forEach
+
+            val tickPart = blocksPerTick / length
+            val tickVec = vec.multiply(
+                tickPart,
+                if (itemEntity.horizontalCollision) tickPart * 2 else tickPart,
+                tickPart
+            )
+            itemEntity.addDeltaMovement(tickVec)
         }
     }
 
     fun invokePickupItemEntity(itemEntity: ItemEntity) {
-        animationScope.launch {
-            trackedItemEntitiesMutex.withLock {
-                if (trackedItemEntities.containsKey(itemEntity)) trackedItemEntities.remove(itemEntity)
-            }
-        }
+        trackedItemEntities.remove(itemEntity)
+    }
+
+    fun tracksItem(itemEntity: ItemEntity) = trackedItemEntities.containsKey(itemEntity)
+
+    private fun untrackEntity(itemEntity: ItemEntity, targetId: UUID) {
+        trackedItemEntities.remove(itemEntity, targetId)
     }
 }


### PR DESCRIPTION
## Summary

- process animated item tracking synchronously on the server tick instead of launching a coroutine for every level tick
- store player UUIDs rather than retaining `ServerPlayer` instances
- stop tracking removed items, unavailable players, and cross-dimension targets
- add a gameplay regression covering cleanup after an animated item is removed

## Root cause

The animation tracker kept strong references from each spawned `ItemEntity` to its target `ServerPlayer` and removed entries only after a successful pickup. Items removed through despawning, unloading, or other lifecycle paths could therefore remain reachable indefinitely. Launching the tracker work on `Dispatchers.Default` each tick also allowed jobs to queue while accessing game entities off the server thread.

## Impact

Animated drops now release stale item and player state on the next tick, and entity movement stays on the server tick thread.

## Verification

- `./gradlew testFast`
- `./gradlew build testGameLatest`

Closes #103